### PR TITLE
fix: correct overlay stacking order for drawer and modal vs header dropdown (Fixes #41)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -29,3 +29,18 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+.ts-app-drawer {
+    position: fixed; /* 確保建立在視窗層級 */
+    z-index: 1050;
+}
+
+.ts-modal {
+    position: fixed;
+    z-index: 1100;
+}
+
+.ts-app-topbar .ts-dropdown,
+.ts-app-topbar .ts-select {
+    z-index: 1000; /* 低於抽屜(1050)與模態(1100) */
+}

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -25,18 +25,18 @@
         class="ts-icon item is-sun-icon" 
         :class="{ 'is-moon-icon': themeStore.isDark }"
         @click="themeStore.toggleTheme"
-        style="z-index: 9999; cursor: pointer;"
+        style="cursor: pointer;"
       ></div>
       
       <!-- 語言選擇選單 -->
-      <div class="ts-select mobile:is-hidden" data-dropdown="select" style="z-index: 9999;">
+      <div class="ts-select mobile:is-hidden" data-dropdown="select">
         <div class="content">
           <span class="ts-flag is-tw-flag"></span>
           <div class="mobile:has-hidden">正體中文</div>
         </div>
       </div>
       
-      <div class="ts-dropdown" data-name="select" data-position="bottom-start" style="z-index: 9999;">
+      <div class="ts-dropdown" data-name="select" data-position="bottom-start">
         <button class="item is-selected">
           <span class="ts-flag is-tw-flag"></span>
           <div class="mobile:has-hidden">正體中文</div>
@@ -54,7 +54,6 @@
       <!-- 手機版選單按鈕 -->
       <button 
         class="mobile:ts-button mobile:is-icon" 
-        style="z-index: 9999;"
         @click="toggleMobileMenu"
       >
         <span class="mobile:ts-icon mobile:is-bars-icon"></span>


### PR DESCRIPTION
- remove fragile inline z-index from AppHeader dropdown/icons
- ensure drawers (1050) and modal (1100) overlay header dropdown (1000)
